### PR TITLE
Ensure FileDataProvider is the default provider

### DIFF
--- a/lib/i18n_data.rb
+++ b/lib/i18n_data.rb
@@ -34,12 +34,10 @@ module I18nData
     end
 
     def data_provider
-      if @data_provider
-        @data_provider
-      else
+      @data_provider ||= (
         require 'i18n_data/file_data_provider'
         FileDataProvider
-      end
+      )
     end
 
     def data_provider=(provider)

--- a/spec/i18n_data_spec.rb
+++ b/spec/i18n_data_spec.rb
@@ -12,6 +12,19 @@ describe I18nData do
     hash.detect{|k,v| k.to_s.empty? or v.to_s.empty?}
   end
 
+  describe ".data_provider" do
+    it "get the current provider" do
+      I18nData.data_provider.should eq I18nData::FileDataProvider
+    end
+
+    it "sets a custom provider" do
+      some_data_provider     = double(:data_provider)
+      I18nData.data_provider = some_data_provider
+
+      I18nData.data_provider.should eq some_data_provider
+    end
+  end
+
   [I18nData::FileDataProvider, I18nData::LiveDataProvider].each do |provider|
     describe "using #{provider}" do
       before :all do


### PR DESCRIPTION
# TL;DR

I noticed another warning that appears only at runtime (I'm using `i18n_data` thru `countries` within `ActiveValidator`). In order to remove it I added a test case on the `data_provider` method as it's responsible for the warning.

# Full explanation
The rewrite of the `data_provider` setter removes a warning that Ruby
detects during execution (when Ruby is executed with the `-w flag`) when we
try to read the `@data_provider` instance variable before initializing it.

This is also why that code couldn't have been written `@data_provider || ...`
because it would have generated yet another warning.

One viable solution is to use the `||=` operator. The reason why it won't
complain is pretty much a side-effect of how Ruby generates the underlying
[bytecode][compile] for the `||=` operator when the left-hand side is `nil`.

Using `||=` comes with a new behavior but there is no guarantee in API,
as of today, that data providers can't be cached.

[compile]: https://github.com/ruby/ruby/blob/7790f37efdd8dd42a0a43c3206f6afdd43f8e86a/compile.c#L4410-L4418