### PR TITLE
Fix failing spec

### DIFF
--- a/lib/i18n_data/file_data_provider.rb
+++ b/lib/i18n_data/file_data_provider.rb
@@ -1,5 +1,7 @@
 module I18nData
   module FileDataProvider
+    require 'fileutils'
+
     DATA_SEPARATOR = ";;"
     extend self
 


### PR DESCRIPTION
The FileDataProvider class doesn't require filutils, but does use it.

The fix is simply to require it.