### PR TITLE
Add German translations for Netherlands Antilles

### DIFF
--- a/cache/file_data_provider/countries-DE.txt
+++ b/cache/file_data_provider/countries-DE.txt
@@ -8,6 +8,7 @@ AO;;Angola
 AI;;Anguilla
 AQ;;Antarktis
 AG;;Antigua und Barbuda
+AN;;Niederländische Antillen
 AR;;Argentinien
 AM;;Armenien
 AW;;Aruba


### PR DESCRIPTION
Add missing German translations for Netherlands Antilles(AN)