### PR TITLE
Extract ISO data from iso-codes JSON

### DIFF
--- a/spec/i18n_data_spec.rb
+++ b/spec/i18n_data_spec.rb
@@ -1,7 +1,10 @@
 # encoding: utf-8
 require "spec_helper"
 
-NUM_2_LETTER_LANGUAGES = 185
+NUM_2_LETTER_LANGUAGES = {
+  I18nData::FileDataProvider => 185,
+  I18nData::LiveDataProvider => 184
+}
 NUM_COUNTRIES = 249
 
 describe I18nData do
@@ -52,7 +55,7 @@ describe I18nData do
           end
 
           it "contains all languages" do
-            I18nData.languages.size.should eq NUM_2_LETTER_LANGUAGES
+            I18nData.languages.size.should eq NUM_2_LETTER_LANGUAGES[provider]
           end
         end
 
@@ -62,7 +65,7 @@ describe I18nData do
           end
 
           it "contains all languages" do
-            I18nData.languages('DE').size.should eq NUM_2_LETTER_LANGUAGES
+            I18nData.languages('DE').size.should eq NUM_2_LETTER_LANGUAGES[provider]
           end
 
           it "has english names for not-translateable languages" do


### PR DESCRIPTION
Update LiveDataProvider to:
1. Use the new iso-codes Git repo URL https://salsa.debian.org/iso-codes-team/iso-codes.git
2. Extract language and country names from iso-codes' JSON data files that have replaced the XML data files

This does not yet update the file data cache which can happen in a follow-up PR if this one is merged.