### PR TITLE
Optimise fetch cache lookup

### DIFF
--- a/lib/i18n_data.rb
+++ b/lib/i18n_data.rb
@@ -47,12 +47,13 @@ module I18nData
 
     private
 
-    def fetch(*args)
+    def fetch(type, language_code)
       @cache ||= {}
-      if @cache.key?(args)
-        @cache[args]
+      @cache[type] ||= {}
+      if @cache[type].key?(language_code)
+        @cache[type][language_code]
       else
-        @cache[args] = yield
+        @cache[type][language_code] = yield
       end
     end
 

--- a/lib/i18n_data.rb
+++ b/lib/i18n_data.rb
@@ -48,13 +48,8 @@ module I18nData
     private
 
     def fetch(type, language_code)
-      @cache ||= {}
-      @cache[type] ||= {}
-      if @cache[type].key?(language_code)
-        @cache[type][language_code]
-      else
-        @cache[type][language_code] = yield
-      end
+      @cache ||= Hash.new { |h, k| h[k] = {} }
+      @cache[type].fetch(language_code) { @cache[type][language_code] = yield }
     end
 
     # hardcode languages that do not have a default type

--- a/spec/benchmark.rb
+++ b/spec/benchmark.rb
@@ -1,0 +1,32 @@
+# Benchmark performance by looking up every available language's country and
+# language translations multiple times.
+
+require 'benchmark'
+require 'i18n_data'
+
+types = %i(countries languages)
+
+type_codes = {}
+types.each do |type|
+  type_codes[type] = []
+  Dir.glob("./cache/file_data_provider/#{type}-*.txt").map do |filename|
+    type_codes[type] << /-(.+)\.txt\z/.match(filename)[1]
+  end
+end
+
+bm = Benchmark.measure do
+  10.times do
+    type_codes.each_pair do |type, codes|
+      codes.each do |code|
+        begin
+          I18nData.send(type, code).keys.each do |key|
+            I18nData.send(type, code)[key]
+          end
+        rescue I18nData::NoTranslationAvailable
+        end
+      end
+    end
+  end
+end
+
+puts bm


### PR DESCRIPTION
Running the included benchmark script with `bundle exec ruby spec/benchmark.rb`:
* On the current master branch: `  0.880000   0.000000   0.880000 (  0.882051)`
* On this branch: `  0.220000   0.010000   0.230000 (  0.231535)`