### PR TITLE
fix country code detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 sudo: false
 cache: bundler
-before_install: gem install bundler
 branches:
   only: master
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.5
-  - 2.2.4
-  - 2.3.0
+  - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6

--- a/spec/i18n_data_spec.rb
+++ b/spec/i18n_data_spec.rb
@@ -162,6 +162,10 @@ describe I18nData do
     it "returns nil when it cannot recognise" do
       I18nData.country_code('XY').should eq nil
     end
+
+    it "can find languages that are not in english list" do
+      I18nData.country_code('奧蘭群島').should eq 'AX'
+    end
   end
 
   describe :language_code do


### PR DESCRIPTION
fixes #41

it could not find 奧蘭群島 because languages en is what we used to iterate and it only knows `ZH;;Chinese` should be better now (iterating over all available languages in file-data-provider), but still not perfect (would need to iterate current data-provider, but not all have an api for all languages ... could add that, but it's more work)
