### PR TITLE
Fix didn't load zh_TW & zh_HK issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 cache: bundler
 branches:
   only: master
+before_install:
+  - ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"
 rvm:
   - 1.9
   - 2.0

--- a/lib/i18n_data.rb
+++ b/lib/i18n_data.rb
@@ -58,7 +58,7 @@ module I18nData
       {
         "ZH" => "zh_CN",
         "BN" => "bn_IN",
-      }[normal] || normal
+      }[normal] || normal.tr('-', '_')
     end
 
     def recognise_code(type, search)

--- a/spec/i18n_data/file_data_provider_spec.rb
+++ b/spec/i18n_data/file_data_provider_spec.rb
@@ -24,6 +24,10 @@ describe I18nData::FileDataProvider do
     File.basename(cache_file).should == "countries-YY_YY.txt"
   end
 
+  it "reads locale name 'zh-TW' correctly when hyphen (-) to underscore (_)" do
+    read(:countries, "zh-TW")["TW"].should == "臺灣"
+  end
+
   it "preserves data when writing and then reading" do
     data = {"x"=>"y","z"=>"w"}
     I18nData::FileDataProvider.send(:write_to_file, data, cache_file)


### PR DESCRIPTION
In rails, I18n.locale is "zh-TW" & "zh-HK", which would not look into correct file in: 

https://github.com/grosser/i18n_data/blob/master/lib/i18n_data.rb#L24

because "zh-TW" would not become "ZH_TW" (dash to underline).

Just let `I18nData.countries('ZH_TW')` can get correct data.