### PR TITLE
Handle searching by multiple names at once

### DIFF
--- a/lib/i18n_data.rb
+++ b/lib/i18n_data.rb
@@ -62,6 +62,16 @@ module I18nData
     end
 
     def recognise_code(type, search)
+      if search.include?(';')
+        found_codes = []
+
+        search.split(';').each do |subsearch|
+          found_codes << recognise_code(type, subsearch)
+        end
+
+        return found_codes.uniq.count == 1 ? found_codes.first : nil
+      end
+
       search = search.strip
 
       # common languages first <-> faster in majority of cases

--- a/spec/i18n_data_spec.rb
+++ b/spec/i18n_data_spec.rb
@@ -186,6 +186,14 @@ describe I18nData do
       I18nData.language_code("   Deutsch \n\r ").should eq 'DE'
     end
 
+    it "recognizes when multiple names of the same language are given" do
+      I18nData.language_code("Valencian; Catalan").should eq 'CA'
+    end
+
+    it "returns nil when names of multiple languages are given" do
+      I18nData.language_code("Valencian; Polish").should eq nil
+    end
+
     it "returns nil when it cannot recognise" do
       I18nData.language_code('XY').should eq nil
     end


### PR DESCRIPTION
Resolves #46 

Handles searching by multiple names of the same object (e.g. language) if names are separated by semicolon.
```ruby
# different names of the same language given
2.7.1 :002 > I18nData.language_code('Catalan; Valencian')
 => "CA" 
# names of two different languages given
2.7.1 :003 > I18nData.language_code('Catalan; Polish')
 => nil 
```
Previous behavior:
```ruby
2.7.1 :002 > I18nData.language_code('Catalan; Valencian')
 => nil 
2.7.1 :003 > I18nData.language_code('Catalan; Polish')
 => nil 
```
@grosser 