### PR TITLE
Add Serbian (Latin)

### DIFF
--- a/cache/file_data_provider/countries-SR@LATIN.txt
+++ b/cache/file_data_provider/countries-SR@LATIN.txt
@@ -1,0 +1,249 @@
+AW;;Aruba
+AF;;Avganistan
+AO;;Angola
+AI;;Angila
+AX;;Ostrva Aland
+AL;;Albanija
+AD;;Andora
+AE;;Ujedinjeni Arapski Emirati
+AR;;Argentina
+AM;;Jermenija
+AS;;Američka Samoa
+AQ;;Antarktik
+TF;;Francuske Južne Teritorije
+AG;;Antigva i Barbuda
+AU;;Australija
+AT;;Austrija
+AZ;;Azerbejdžan
+BI;;Burundi
+BE;;Belgija
+BJ;;Benin
+BQ;;Boner, Sveti Eustahije i Saba
+BF;;Burkina Faso
+BD;;Bangladeš
+BG;;Bugarska
+BH;;Bahrein
+BS;;Bahami
+BA;;Bosna i Hercegovina
+BL;;Sveti Bartolomej
+BY;;Belorusija
+BZ;;Belize
+BM;;Bermuda
+BO;;Bolivija
+BR;;Brazil
+BB;;Barbados
+BN;;Sultanat Bruneji
+BT;;Butan
+BV;;Ostrvo Bov
+BW;;Bocvana
+CF;;Centralnoafrička Republika
+CA;;Kanada
+CC;;Kokosova ostrva
+CH;;Švajcarska
+CL;;Čile
+CN;;Kina
+CI;;Obala Slonovače
+CM;;Kamerun
+CD;;Kongo, Demokratska Republika
+CG;;Kongo
+CK;;Ostrva Kuk
+CO;;Kolumbija
+KM;;Komori
+CV;;Zelenortska ostrva
+CR;;Kostarika
+CU;;Kuba
+CW;;Kurasao
+CX;;Božićno ostrvo
+KY;;Ostrva Kajman
+CY;;Kipar
+CZ;;Češka
+DE;;Nemačka
+DJ;;Džibuti
+DM;;Dominika
+DK;;Danska
+DO;;Dominikanska Republika
+DZ;;Alžir
+EC;;Ekvador
+EG;;Egipat
+ER;;Eritreja
+EH;;Zapadna Sahara
+ES;;Španija
+EE;;Estonija
+ET;;Etiopija
+FI;;Finska
+FJ;;Fidži
+FK;;Folklandska ostrva (Malvini)
+FR;;Francuska
+FO;;Farska ostrva
+FM;;Mikronezija, Federalne Države
+GA;;Gabon
+GB;;Ujedinjeno Kraljevstvo
+GE;;Gruzija
+GG;;Gernsi
+GH;;Gana
+GI;;Gibraltar
+GN;;Gvineja
+GP;;Gvadalupe
+GM;;Gambija
+GW;;Gvineja-Bisao
+GQ;;Ekvatorijalna Gvineja
+GR;;Grčka
+GD;;Grenada
+GL;;Grenland
+GT;;Gvatemala
+GF;;Francuska Gvajana
+GU;;Giam
+GY;;Gvajana
+HK;;Hong Kong
+HM;;Ostrvo Herd i ostrva Mekdonald
+HN;;Honduras
+HR;;Hrvatska
+HT;;Haiti
+HU;;Mađarska
+ID;;Indonezija
+IM;;Ostrvo Man
+IN;;Indija
+IO;;Britanska Indijska Okeanska Teritorija
+IE;;Irska
+IR;;Iran, Islamska Republika
+IQ;;Irak
+IS;;Island
+IL;;Izrael
+IT;;Italija
+JM;;Jamajka
+JE;;Džersi
+JO;;Jordan
+JP;;Japan
+KZ;;Kazahstan
+KE;;Kenija
+KG;;Kirgistan
+KH;;Kambodža
+KI;;Kiribati
+KN;;Sveti Kits i Nevis
+KR;;Koreja, Republika
+KW;;Kuvajt
+LA;;Laoška Narodna Demokratska Republika
+LB;;Liban
+LR;;Liberija
+LY;;Libija
+LC;;Sveta Lucija
+LI;;Lihtenštajn
+LK;;Šri Lanka
+LS;;Lesoto
+LT;;Litvanija
+LU;;Luksemburg
+LV;;Letonija
+MO;;Makao
+MF;;Sveti Martin (francuski deo)
+MA;;Maroko
+MC;;Monako
+MD;;Moldavija
+MG;;Madagaskar
+MV;;Maldivi
+MX;;Meksiko
+MH;;Maršalska ostrva
+MK;;Severna Makedonija
+ML;;Mali
+MT;;Malta
+MM;;Burma
+ME;;Crna Gora
+MN;;Mongolija
+MP;;Severna Marijanska ostrva
+MZ;;Mozambik
+MR;;Mauritanija
+MS;;Monserat
+MQ;;Martinik
+MU;;Mauricijus
+MW;;Malavi
+MY;;Malezija
+YT;;Majot
+NA;;Namibija
+NC;;Nova Kaledonija
+NE;;Niger
+NF;;Ostrvo Norfolk
+NG;;Nigerija
+NI;;Nikaragva
+NU;;Niue
+NL;;Holandija
+NO;;Norveška
+NP;;Nepal
+NR;;Nauru
+NZ;;Novi Zeland
+OM;;Oman
+PK;;Pakistan
+PA;;Panama
+PN;;Pitkarn
+PE;;Peru
+PH;;Filipini
+PW;;Palau
+PG;;Papua Nova Gvineja
+PL;;Poljska
+PR;;Portoriko
+KP;;Koreja, Demokratska Narodna Republika
+PT;;Portugal
+PY;;Paragvaj
+PS;;Palestina, Država
+PF;;Francuska Polinezija
+QA;;Katar
+RE;;Reunion
+RO;;Rumunija
+RU;;Ruska Federacija
+RW;;Ruanda
+SA;;Saudijska Arabija
+SD;;Sudan
+SN;;Senegal
+SG;;Singapur
+GS;;Južna Džordžija i Južna Sendvič ostrva
+SH;;Sveta Jelena, Asansion i Tristan da Kuna
+SJ;;Svalbard i Jan Majen
+SB;;Ostrva Solomon
+SL;;Sijera Leone
+SV;;El Salvador
+SM;;San Marino
+SO;;Somalija
+PM;;Sveti Pjer i Mikelon
+RS;;Srbija
+SS;;Južni Sudan
+ST;;Sao Tome i Principe
+SR;;Surinam
+SK;;Slovačka
+SI;;Slovenija
+SE;;Švedska
+SZ;;Esvatini
+SX;;Sveti Martin (holandski deo)
+SC;;Sejšeli
+SY;;Sirijska Arapska Republika
+TC;;Ostrva Turks i Kaikos
+TD;;Čad
+TG;;Togo
+TH;;Tajland
+TJ;;Tadžikistan
+TK;;Tokelau
+TM;;Turkmenistan
+TL;;Istočni Timor
+TO;;Tonga
+TT;;Trinidad i Tobago
+TN;;Tunis
+TR;;Turska
+TV;;Tuvalu
+TW;;Tajvan
+TZ;;Tanzanija
+UG;;Uganda
+UA;;Ukrajina
+UM;;Spoljna ivična ostrva SAD
+UY;;Urugvaj
+US;;Sjedinjene Države
+UZ;;Uzbekistan
+VA;;Sveta Stolica (Država grada Vatikana)
+VC;;Sveti Vinsent i Grenadini
+VE;;Venecuela
+VG;;Devičanska ostrva, Britanska
+VI;;Devičanska ostrva, SAD
+VN;;Vijetnam
+VU;;Vanuatu
+WF;;Valis i Futuna
+WS;;Samoa
+YE;;Jemen
+ZA;;Južna Afrika
+ZM;;Zambija
+ZW;;Zimbabve

--- a/cache/file_data_provider/languages-SR@LATIN.txt
+++ b/cache/file_data_provider/languages-SR@LATIN.txt
@@ -1,0 +1,184 @@
+AA;;afarski
+AB;;abkaski
+AF;;afrikanski
+AK;;akanski
+AM;;amharski
+AR;;arapski
+AN;;aragonski
+AS;;asameški
+AV;;avarski
+AE;;avestansko pismo
+AY;;ajmarski
+AZ;;azerbejdžanski
+BA;;baškirski
+BM;;bambaraški
+BE;;beloruski
+BN;;banglaški
+BH;;bihaški jezici
+BI;;bislameški
+BO;;tibetski
+BS;;bošnjački
+BR;;bretonski
+BG;;bugarski
+CA;;katalonski; valensijski
+CS;;češki
+CH;;čamorski
+CE;;čečenski
+CU;;crkvenoslovenski; staroslovenski; starobugarski; stari crkvenoslovenski
+CV;;čuvaški
+KW;;kornvalski
+CO;;korzikanski
+CR;;kriški
+CY;;velški
+DA;;danski
+DE;;nemački
+DV;;divehški; maldivski
+DZ;;dzongeški
+EL;;grčki, savremeni (1453.—)
+EN;;engleski
+EO;;esperanto
+ET;;estonski
+EU;;baskijski
+EE;;evski
+FO;;farski
+FA;;persijski
+FJ;;fidžiski
+FI;;finski
+FR;;francuski
+FY;;zapadnofrizijski
+FF;;fulški
+GD;;galski; škotski galski
+GA;;irski
+GL;;galicijski
+GV;;manski
+GN;;gvaranski
+GU;;guđaratsko pismo
+HT;;haićanski; haićanski kreolski
+HA;;hauski
+HE;;hebrejski
+HZ;;hererski
+HI;;hindu
+HO;;hiri motuški
+HR;;hrvatski
+HU;;mađarski
+HY;;jermenski
+IG;;iboški
+IO;;idoski
+II;;sičuanski ji; nuoški
+IU;;inuktitutski
+IE;;interlingve; zapadnjački
+IA;;interjezik (međunarodno udruženje sporednih jezika
+ID;;indonežanski
+IK;;inupjaški
+IS;;islandski
+IT;;italijanski
+JV;;javanski
+JA;;japanski
+KL;;kalski; grenlandski
+KN;;kannada pismo
+KS;;kašmirski
+KA;;gruzijski
+KR;;kanurski
+KK;;kazahstanski
+KM;;središnji kmerski
+KI;;kikujski; gikujski
+RW;;kinjarvandski
+KY;;kirgiški
+KV;;komski
+KG;;kongoanski
+KO;;korejski
+KJ;;kuanjamski; kvanjamski
+KU;;kurdski
+LO;;laosko pismo
+LA;;latinski
+LV;;letonski
+LI;;limburganski; limburgerski; limburgiški
+LN;;lingalski
+LT;;litvanski
+LB;;luksemburški; leceburški
+LU;;luba-katanški
+LG;;gandski
+MH;;maršalski
+ML;;malajalamsko pismo
+MR;;maratski
+MK;;makedonski
+MG;;malagaški
+MT;;malteški
+MN;;mongolski
+MI;;maorski
+MS;;malajski
+MY;;burmanski
+NA;;naurski
+NV;;navašanski
+NR;;ndebelski, južni; južni ndebelski
+ND;;ndebelski, severni; severni ndebelski
+NG;;ndonški
+NE;;nepalski
+NL;;holandski; flaminski
+NN;;norveški ninorški; ninorški, norveški
+NB;;bokmalski, norveški; norveški bokmalski
+NO;;norveški
+NY;;čevski; čičevski; njandžiski
+OC;;oksitanski (posle 1500.); provansalski
+OJ;;odžibski
+OR;;orijski
+OM;;oromski
+OS;;osetijski; osetski
+PA;;pandžabski
+PI;;palski
+PL;;poljski
+PT;;portugalski
+PS;;puštski; paštski
+QU;;kečuški
+RM;;romski
+RO;;rumunski; moldovijski; moldavski
+RN;;rundski
+RU;;ruski
+SG;;sanški
+SA;;sanskritski
+SI;;sinhalski; sinhaleški
+SK;;slovački
+SL;;slovenački
+SE;;severnosamski
+SM;;samoanski
+SN;;šonski
+SD;;sindski
+SO;;somalski
+ST;;sotski, južni
+ES;;španski; kastiljski
+SQ;;albanski
+SC;;sardinijski
+SR;;srpski
+SS;;svatski
+SU;;sundansko pismo
+SW;;svahilski
+SV;;švedski
+TY;;tahićanski
+TA;;tamilsko pismo
+TT;;tatarski
+TE;;telugu pismo
+TG;;tadžiški
+TL;;tagaloški
+TH;;tajlandski
+TI;;tigrinjski
+TO;;tonški (Tonga ostrva)
+TN;;cvanski
+TS;;conški
+TK;;turkmenski
+TR;;turski
+TW;;tviški
+UG;;uigurski; ujgurski
+UK;;ukrajinski
+UR;;urdski
+UZ;;uzbekistanski
+VE;;vendski
+VI;;vijetnamski
+VO;;volapiški
+WA;;valunski
+WO;;volofski
+XH;;ksoški
+YI;;jidiški
+YO;;jorubski
+ZA;;žuanški; čuanški
+ZH;;kineski
+ZU;;zulski

--- a/lib/i18n_data/file_data_provider.rb
+++ b/lib/i18n_data/file_data_provider.rb
@@ -13,7 +13,7 @@ module I18nData
     end
 
     def write_cache(provider)
-      languages = provider.codes(:languages, 'EN').keys + ['zh_CN', 'zh_TW', 'zh_HK','bn_IN','pt_BR']
+      languages = provider.codes(:languages, 'EN').keys + ['zh_CN', 'zh_TW', 'zh_HK', 'bn_IN', 'pt_BR', 'sr@latin']
       languages.map do |language_code|
         [:languages, :countries].each do |type|
           begin

--- a/spec/i18n_data_spec.rb
+++ b/spec/i18n_data_spec.rb
@@ -91,6 +91,10 @@ describe I18nData do
           it "has language subtypes" do
             I18nData.languages('zh_TW')['DA'].should eq '丹麥語'
           end
+
+          it "has language scripts" do
+            I18nData.languages('SR@LATIN')['DA'].should eq 'danski'
+          end
         end
       end
 
@@ -159,6 +163,10 @@ describe I18nData do
 
           it "has language subtypes" do
             I18nData.countries('zh_TW')['DK'].should eq '丹麥'
+          end
+
+          it "has language scripts" do
+            I18nData.countries('SR@LATIN')['DK'].should eq 'Danska'
           end
         end
       end


### PR DESCRIPTION
Currently, only the Serbian translations using the Cyrillic script are available (using code `SR`). The [iso-codes](https://salsa.debian.org/iso-codes-team/iso-codes) project also provides the Serbian translations using the Latin/Western script.

This PR makes those Latin translations available using the `SR@LATIN` code.